### PR TITLE
添加绪论的半角空白字符

### DIFF
--- a/body/chapter01.tex
+++ b/body/chapter01.tex
@@ -1,7 +1,7 @@
 % !TEX root = ../main.tex
 
 % 中英标题：\chapter{中文标题}[英文标题]
-\chapter{绪~~~~论}[Introduction]
+\chapter{绪\hspace{1em}论}[Introduction]
 % 绪论也需像摘要、目录格式那样空出两个半角字符。
 
 \section{课题背景及研究的目的和意义}[Background, objective and significance of the subject]

--- a/body/chapter01.tex
+++ b/body/chapter01.tex
@@ -1,7 +1,8 @@
 % !TEX root = ../main.tex
 
 % 中英标题：\chapter{中文标题}[英文标题]
-\chapter{绪论}[Introduction]
+\chapter{绪~~~~论}[Introduction]
+% 绪论也需像摘要、目录格式那样空出两个半角字符。
 
 \section{课题背景及研究的目的和意义}[Background, objective and significance of the subject]
 


### PR DESCRIPTION
根据[本科毕业论文（设计）书写范例（理工类）](http://due.hitsz.edu.cn/sjjiaoxue/bysj_lw_/xgxz.htm)
绪论这两个字中间应该有两个半角空白字符，而非紧挨着。
<img width="591" alt="image" src="https://github.com/YangLaTeX/hitszthesis/assets/82895469/78685409-197e-47da-ad1e-77c5502b0819">